### PR TITLE
Expand package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,13 +4,18 @@ from distutils.core import setup
 setup(name='pycrunch-trace',
       version='0.1.5',
       description='PyCrunch Time Travel Debugger',
-      url='http://github.com/gleb-sevruk/pycrunch-trace',
+      url='https://pytrace.com/',
       author='Gleb Sevruk',
       author_email='gleb@pycrunch.com',
-      license='libpng',
-      keywords="tracing time travel debugging live coding",
+      license='MIT',
+      keywords=[
+          'tracing',
+          'debugging',
+          'time-travel debugging',
+          'record-and-replay debugging',
+          'live coding',
+      ],
       packages=setuptools.find_packages(),
-      download_url='https://github.com/gleb-sevruk/pycrunch-trace/archive/v0.1.0.tar.gz',
       setup_requires=['wheel', 'Cython'],
       install_requires=[
           'Cython',
@@ -18,5 +23,15 @@ setup(name='pycrunch-trace',
           'PyYAML',
           'protobuf==3.11.3'
       ],
+      classifiers=[
+          'Development Status :: 3 - Alpha',
+          'License :: OSI Approved :: MIT License',
+          'Programming Language :: Python :: 3',
+          'Topic :: Software Development :: Debuggers',
+      ],
+      project_urls={
+          'Source': 'https://github.com/gleb-sevruk/pycrunch-trace/',
+          'Funding': 'https://pycrunch.com/donate',
+      },
       include_package_data=True,
       zip_safe=False)


### PR DESCRIPTION
(the second half of the license PR)

These changes make it easier to find - and donate to - pycrunch-trace via PyPI, by using the more recent metadata standards to add some additional links and ensure that keywords and classifiers are properly searchable.

You'll need to publish an update, e.g. version 0.1.6 with only metadata changes, before this is visible.

(and also, [consider setting up GitHub Sponsors](https://docs.github.com/en/sponsors/receiving-sponsorships-through-github-sponsors/setting-up-github-sponsors-for-your-user-account)?  I'd chip in!)