### PR TITLE
Hot-fix when there is no recording name provided to Trace().start(); …

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2021 Gleb Sevruk and other contributors
+Copyright (c) 2021-2022 Gleb Sevruk and other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -35,10 +35,45 @@ some_code()
 tracer.stop()
 ```
 
+
 Optional session_name can be also passed to decorator:
 ```python
 @trace('my_custom_recording_name')
 ``` 
+
+### Specifying custom folders/files to exclude 
+this will greatly speed-up profiler, however calls to the ignored directories will be ignored. 
+
+Exclusion will be considered if absolute file path either `starts_with` or `ends_with` with given stop-list. 
+
+```python
+from pycrunch_trace.client.api import Trace
+ 
+t = Trace()
+t.start(additional_excludes=[
+             '/Users/gleb/.venvs/pycrunch_trace'
+             '/Users/gleb/.pyenv/versions/3.6.15/',
+             'unwanted_file.py',
+        ])
+
+some_code()
+
+t.stop()
+
+```
+
+This is also possible via decorator:
+
+```python
+from pycrunch_trace.client.api import trace
+
+@trace(additional_excludes=['/Users/gleb/.venvs/pycrunch_trace'])
+def run():
+    some_code()
+```
+
+
+
 
 Use web app for replaying recording:
 

--- a/pycrunch_trace/client/api/trace_decorator.py
+++ b/pycrunch_trace/client/api/trace_decorator.py
@@ -3,13 +3,17 @@ from pycrunch_trace.client.api.trace import Trace
 
 
 
-def trace(session_name_or_func=None, *decorator_args, **decorator_kws):
+def trace(session_name_or_func=None, additional_excludes=None, *decorator_args, **decorator_kws):
     """
        Starts tracing using PyCrunch tracing toolkit
    """
     def _decorator(func):
         @wraps(func)
         def wrapper(*args, **kws):
+            internal_additional_exclude = None
+            if 'additional_excludes' in locals():
+                internal_additional_exclude = additional_excludes
+
             if 'session_name_or_func' not in locals() \
                     or callable(session_name_or_func) \
                     or session_name_or_func is None:
@@ -17,7 +21,7 @@ def trace(session_name_or_func=None, *decorator_args, **decorator_kws):
             else:
                 session_name = session_name_or_func
             pycrunch_tracer = Trace()
-            pycrunch_tracer.start(session_name)
+            pycrunch_tracer.start(session_name, additional_excludes=internal_additional_exclude)
             try:
                 results = func(*args, **kws)
                 return results

--- a/pycrunch_trace/filters/CustomFileFilter.py
+++ b/pycrunch_trace/filters/CustomFileFilter.py
@@ -1,3 +1,5 @@
+from typing import List
+
 import yaml
 
 from . import AbstractFileFilter
@@ -9,6 +11,7 @@ class CustomFileFilter(AbstractFileFilter):
     _trace_variables: bool
     profile_file: AbstractFile
     _loaded: bool
+
 
     def __init__(self, profile_file: AbstractFile):
         self.profile_file = profile_file
@@ -46,6 +49,15 @@ class CustomFileFilter(AbstractFileFilter):
             for e in exclusions:
                 tmp.add(e)
         self.exclusions = tuple(tmp)
+
+    def add_additional_exclusions(self, additional_excludes: List[str]):
+        if len(additional_excludes) <= 0:
+            return
+        exclusions_copy = set(self.exclusions)
+        for exclude in additional_excludes:
+            exclusions_copy.add(exclude)
+
+        self.exclusions = tuple(exclusions_copy)
 
     def load_variables(self, all):
         trace_vars = all.get('trace_variables')

--- a/pycrunch_trace/tests/test_exclusions.py
+++ b/pycrunch_trace/tests/test_exclusions.py
@@ -1,0 +1,17 @@
+from pathlib import Path
+
+from pycrunch_trace.filters import CustomFileFilter
+from pycrunch_trace.oop import File
+
+
+def test_additional_exclusions_considered():
+    package_directory = Path(__file__).parent.parent
+
+    sut = CustomFileFilter(File(package_directory.joinpath('pycrunch-profiles', 'default.profile.yaml')))
+    sut._ensure_loaded()
+    sut.add_additional_exclusions(['/this/is/excluded'])
+
+    actual = sut.should_trace('/this/is/excluded/some.py')
+    assert actual is False
+
+    assert sut.should_trace('/this/is/included/main.py')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,5 @@
-# python-socketio==4.4.0
-# python-socketio[client]==4.4.0
-
-# aiohttp==3.6.2
-# aiohttp-devtools
-# aiohttp_debugtoolbar
-# jsonpickle
-
 wheel
 PyYAML
-protobuf==3.11.3
+protobuf>=3.11.3
 Cython
+jsonpickle

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import setuptools
 from distutils.core import setup
 
 setup(name='pycrunch-trace',
-      version='0.1.6',
+      version='0.2',
       description='PyCrunch Time Travel Debugger',
       url='https://pytrace.com/',
       author='Gleb Sevruk',
@@ -21,7 +21,8 @@ setup(name='pycrunch-trace',
           'Cython',
           'jsonpickle',
           'PyYAML',
-          'protobuf==3.11.3'
+          'protobuf>=3.11.3',
+          'jsonpickle',
       ],
       classifiers=[
           'Development Status :: 3 - Alpha',


### PR DESCRIPTION
Hot-fix when there is no recording name provided to Trace().start(); 

Added ability to use custom exclusions right in the decorator or in Trace.start method.