### PR TITLE
Fix dependencies issues + Python 3.11 support #12

### DIFF
--- a/pycrunch_trace/native/native_models.pxd
+++ b/pycrunch_trace/native/native_models.pxd
@@ -12,7 +12,7 @@ cdef class NativeStackFrame:
     cdef int id
 
 cdef class NativeCodeEvent:
-    cpdef str event_name
+    cdef str event_name
     cdef NativeExecutionCursor cursor
     cdef NativeStackFrame stack
     cdef double ts

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 wheel
 PyYAML
-protobuf>=3.11.3
+protobuf>=3.11.3,<4.0.0
 Cython
 jsonpickle


### PR DESCRIPTION
1) Currenly `pip install pycrunch-trace` installs version that will never work because:
- pip will install Cython 3.0.0 which is not supported by the package
- pip will install protobuf 4.0.0 which is not supported by the packages

2) Even if we fallback to the older version manually using `pip install protobuf==3.11.3 Cython==0.29.27`, package will work on Python 3.10 but it still breaks on Python 3.11 (I guess Python 3.11 requires Cython 3+).

3) This PR solves both dependencies issue and python 3.11 problem:
- set upper bound for protobuf to ensure it will be supported version <4.0.0
- fix compilation issue on Cython 3 and that allows us support both Cython 3+ in general and Python 3.11